### PR TITLE
Update command usage descriptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ verboseOutput = true
 
 [tool.pytest.ini_options]
 addopts = [
-    "-rA -q",
+    "-q",
     "--doctest-modules",
     "--ignore=build.py",        # Don't check build.py
     "--cov=.",

--- a/src/urload/commands/add.py
+++ b/src/urload/commands/add.py
@@ -11,7 +11,7 @@ class AddCommand(Command):
 
     name = "add"
     description = textwrap.dedent("""
-    Usage: add <url> - Add a URL to the list.
+    add <url> - Add a URL to the list.
 
     This command appends the specified URL to the shared URL list.
     """)

--- a/src/urload/commands/del.py
+++ b/src/urload/commands/del.py
@@ -12,7 +12,7 @@ class DelCommand(Command):
 
     name = "del"
     description = textwrap.dedent("""
-    Usage: del <index> | del <start>-<end> - Delete one or more URLs by index or range.
+    del <index> | <start>-<end> - Delete one or more URLs by index or range.
 
     This command removes a single URL by index or a range of URLs from the list.
     """)

--- a/src/urload/commands/exit.py
+++ b/src/urload/commands/exit.py
@@ -11,7 +11,7 @@ class ExitCommand(Command):
 
     name = "exit"
     description = textwrap.dedent("""
-    Usage: exit - Exit the application.
+    exit - Exit the application.
 
     This command exits the URLoad interactive session.
     """)

--- a/src/urload/commands/head.py
+++ b/src/urload/commands/head.py
@@ -11,7 +11,7 @@ class HeadCommand(Command):
 
     name = "head"
     description = textwrap.dedent("""
-    Usage: head <n> - Keep the first n URLs from the list.
+    head <n> - Keep the first n URLs from the list.
 
     This command keeps only the first n URLs in the list, discarding the rest.
     """)

--- a/src/urload/commands/help.py
+++ b/src/urload/commands/help.py
@@ -11,7 +11,7 @@ class HelpCommand(Command):
 
     name = "help"
     description = textwrap.dedent("""
-    Usage: help [command] - Show help for a command.
+    help [command] - Show help for a command.
 
     With no arguments, lists all available commands. With a command name,
     shows detailed help for that command.
@@ -26,9 +26,14 @@ class HelpCommand(Command):
         if not args:
             print("Available commands:")
             for cmd in sorted(self.commands):
-                print(
-                    f"  {cmd}: {self.commands[cmd].description.splitlines()[0].strip()}"
-                )
+                # Print only the first non-empty line of the description (short help)
+                desc_lines = [
+                    line.strip()
+                    for line in self.commands[cmd].description.splitlines()
+                    if line.strip()
+                ]
+                short_help = desc_lines[0] if desc_lines else ""
+                print(f"  {short_help}")
             print("Type 'help <command>' for more info.")
         else:
             cmd = args[0]

--- a/src/urload/commands/list.py
+++ b/src/urload/commands/list.py
@@ -11,7 +11,7 @@ class ListCommand(Command):
 
     name = "list"
     description = textwrap.dedent("""
-    Usage: list - List all URLs in the current list.
+    list - List all URLs in the current list.
 
     This command prints each URL in the list, prefixed with its index.
     """)

--- a/src/urload/commands/scrape.py
+++ b/src/urload/commands/scrape.py
@@ -11,7 +11,7 @@ class ScrapeCommand(Command):
 
     name = "scrape"
     description = textwrap.dedent("""
-    Usage: scrape <url> - Scrape a website.
+    scrape <url> - Scrape a website.
 
     This command scrapes the content of the specified URL and processes it.
     """)

--- a/src/urload/commands/tail.py
+++ b/src/urload/commands/tail.py
@@ -11,7 +11,7 @@ class TailCommand(Command):
 
     name = "tail"
     description = textwrap.dedent("""
-    Usage: tail <n> - Keep the last n URLs from the list.
+    tail <n> - Keep the last n URLs from the list.
 
     This command keeps only the last n URLs in the list, discarding the rest.
     """)
@@ -29,7 +29,4 @@ class TailCommand(Command):
         if n < 0:
             raise CommandError("Count must be non-negative.")
 
-        if n == 0:
-            return []
-
-        return url_list[-n:]
+        return url_list[-n:] if n > 0 else []

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -24,7 +24,7 @@ def test_help_lists_commands(capsys: CaptureFixture[str]) -> None:
     help_cmd = HelpCommand(commands)
     help_cmd.run([], [])
     captured = capsys.readouterr()
-    assert "dummy" in captured.out
+    assert "Dummy command." in captured.out
     assert "Available commands" in captured.out
 
 


### PR DESCRIPTION
This pull request focuses on improving the consistency and readability of command descriptions and refining the logic in the `help` and `tail` commands. The most important changes include standardizing the format of command descriptions across all commands, enhancing the `help` command to display cleaner short descriptions, and simplifying the logic in the `tail` command's `run` method.

### Improvements to command descriptions:

* Standardized the format of command descriptions by removing the redundant "Usage:" prefix in the following files:
  - `src/urload/commands/add.py` (`AddCommand`)
  - `src/urload/commands/del.py` (`DelCommand`)
  - `src/urload/commands/exit.py` (`ExitCommand`)
  - `src/urload/commands/head.py` (`HeadCommand`)
  - `src/urload/commands/help.py` (`HelpCommand`)
  - `src/urload/commands/list.py` (`ListCommand`)
  - `src/urload/commands/scrape.py` (`ScrapeCommand`)
  - `src/urload/commands/tail.py` (`TailCommand`)

### Enhancements to the `help` command:

* Modified the `help` command to display only the first non-empty line of each command's description as a short summary, improving readability when listing available commands.

### Refinements to the `tail` command:

* Simplified the `run` method in the `tail` command to return an empty list when `n` is zero, instead of using an explicit conditional block.