### PR TITLE
Update Renovate config to use best-practices

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   // Renovate docs: https://docs.renovatebot.com/configuration-options/
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended", // Use recommended settings
+    "config:best-practices", // Use Renovate best-practices
     "docker:pinDigests", // Pin container digests
     "helpers:pinGitHubActionDigests", // Pin GitHub action digests
     ":enablePreCommit", // Enable updates to pre-commit repos


### PR DESCRIPTION
This pull request updates the Renovate configuration to align with best practices by replacing the recommended settings with the best-practices configuration.

* [`.github/renovate.json5`](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790L6-R6): Changed the configuration from `"config:recommended"` to `"config:best-practices"` to follow Renovate's best-practices guidelines.