### PR TITLE
Add SBOM generation to CI workflow

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -106,3 +106,40 @@ jobs:
     steps:
       - name: Success
         run: echo "Previous jobs were successful"
+
+  sbom:
+    name: Software Bill of Materials
+    permissions:
+      actions: read
+      contents: write
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main') }}
+
+    steps:
+      - name: Checkout repository
+        # https://github.com/actions/checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        # https://github.com/astral-sh/setup-uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+
+      - name: Set up Python
+        # https://github.com/actions/setup-python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Generate requirements.txt
+        run: uv export --locked --format requirements-txt > requirements.txt
+
+      - name: Generate & upload SBOM
+        # https://github.com/anchore/sbom-action
+        uses: anchore/sbom-action@cee1b8e05ae5b2593a75e197229729eabaa9f8ec # v0.20.2
+        with:
+          artifact-name: sbom-spdx.json
+          dependency-snapshot: true
+          file: requirements.txt
+          format: spdx-json


### PR DESCRIPTION
This pull request introduces a new `sbom` job to the CI workflow in `.github/workflows/ci-workflow.yaml`. The `sbom` job is designed to generate and upload a Software Bill of Materials (SBOM) for the project. Below are the key details of the changes:

### Addition of the `sbom` job:
* **Job Name and Permissions**: A new job named `Software Bill of Materials` has been added. It includes permissions for reading actions and writing contents.
* **Trigger Conditions**: The job runs only on `push` or `workflow_dispatch` events targeting the `main` branch.
* **Steps in the Job**:
  - **Repository Checkout**: Uses the `actions/checkout` action to fetch the repository with a `fetch-depth` of 0.
  - **Install `uv`**: Sets up the `uv` tool using the `astral-sh/setup-uv` action.
  - **Set Up Python**: Configures Python using the `actions/setup-python` action with the version specified in `.python-version`.
  - **Generate `requirements.txt`**: Runs `uv export` to create a