### PR TITLE
Update CI workflow and project files for v0.9.0 release

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
@@ -95,18 +95,6 @@ jobs:
       - name: Pyright
         run: uv run pyright
 
-  # This is a dummy job to determine success of the CI workflow
-  ci-success:
-    name: CI Workflow - Success
-    needs:
-      - devcontainer
-      - pre-commit
-      - test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Success
-        run: echo "Previous jobs were successful"
-
   sbom:
     name: Software Bill of Materials
     permissions:
@@ -143,3 +131,43 @@ jobs:
           dependency-snapshot: true
           file: requirements.txt
           format: spdx-json
+
+  # This is a dummy job to determine success of the CI workflow
+  ci-success:
+    name: CI Workflow - Success
+    needs:
+      - devcontainer
+      - pre-commit
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "Previous jobs were successful"
+
+  # This job publishes the package to PyPI when a new tag is pushed
+  publish:
+    name: "Publish to PyPI"
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    needs:
+      - ci-success
+    runs-on: ubuntu-latest
+    env:
+      UV_LOCKED: true
+    permissions:  # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+      contents: read
+      id-token: write  # Required for publishing to PyPI via trusted publisher
+
+    steps:
+      - name: Checkout repository
+        # https://github.com/actions/checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install uv
+        # https://github.com/astral-sh/setup-uv
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+
+      - name: Build release artifacts
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ extracting and managing web data simple and efficient.
 ## Installation
 
 ```console
-pip install --user git+https://github.com/JohnStrunk/urload
+pip install --user urload
 ```
 
 ## Usage
@@ -30,19 +30,21 @@ URLoad (0) >
 
 ### Common Commands
 
-- `add <url>`: Add a URL to the session
-- `list`: List all URLs in the session
-- `get <url>`: Fetch and display content from a URL
-- `img <url>`: Extract image links from a URL
-- `href <url>`: Extract hyperlinks from a URL
-- `save <filename>`: Save session data to a file
-- `load <filename>`: Load session data from a file
-- `sort`: Sort URLs or results
-- `uniq`: Remove duplicate entries
+- `add <url>`: Add a URL to the current list
+- `list`: List all URLs
+- `get`: Fetch all URLs in the current list
+- `img <url>`: Extract image links from the current list
+- `href <url>`: Extract hyperlinks from the current list
+- `save <filename>`: Save the current URL list to a file
+- `load <filename>`: Load the URL list from a file
+- `sort`: Sort the URL list alphabetically
+- `uniq`: Remove duplicate URLs
 - `help`: Show help for commands
 
-All commands can be explored interactively. Use `help` for details on each
-command.
+All commands can be explored interactively.
+
+- Use `help` to list available commands.
+- Use `help <command>` to get detailed help for a specific command.
 
 ## Development
 
@@ -51,6 +53,8 @@ The project uses [uv](http://astral.sh/uv) for dependency management.
 To run the project locally, clone the repository and run with `uv`:
 
 ```console
+git clone https://github.com/JohnStrunk/URLoad.git
+cd URLoad
 uv run urload
 ```
 
@@ -64,6 +68,16 @@ To run all tests and code checks:
 
 This will run linting, formatting, and all unit tests.
 
----
+## License
 
-See [LICENSE](LICENSE) for licensing information.
+**SPDX-License-Identifier:** AGPL-3.0-or-later
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,22 @@ build-backend = "uv_build"
 
 [project]
 name = "urload"
-version = "0.1.0"
+version = "0.9.0"
 description = "An interactive tool for downloading URLs"
 authors = [{ name = "John Strunk", email = "john.strunk@gmail.com" }]
 requires-python = ">=3.13"
+readme = "README.md"
+classifiers = [  # https://pypi.org/classifiers/
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Utilities",
+]
+license = "AGPL-3.0-or-later"
+license-files = ["LICENSE"]
 dependencies = [
     "beautifulsoup4==4.13.4",
     "prompt-toolkit==3.0.51",
@@ -15,6 +27,9 @@ dependencies = [
     "requests==2.32.4",
     "tomlkit==0.13.3",
 ]
+
+[project.urls]
+Homepage = "https://github.com/JohnStrunk/URLoad"
 
 [dependency-groups]
 dev = [

--- a/release.md
+++ b/release.md
@@ -1,0 +1,13 @@
+# Release steps
+
+- Update the version in `pyproject.toml`
+
+  ```console
+  # Bump the version string
+  uv version --bump {major|minor|patch|alpha|beta|stable}
+  # or specify the version directly
+  uv version X.Y.Z
+  ```
+
+- Commit changes to `main`
+- Tag the repo with the new version: `vX.Y.Z`

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ wheels = [
 
 [[package]]
 name = "urload"
-version = "0.1.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
This pull request introduces several updates to improve the CI workflow, documentation, and project metadata for the `URLoad` tool. Key changes include refining the CI workflow to support PyPI publishing, enhancing the `README.md` for clarity and completeness, and updating the `pyproject.toml` file with additional metadata and licensing information.

### CI Workflow Enhancements:
* Updated `.github/workflows/ci-workflow.yaml` to only trigger on tags starting with `v` for the `push` event. This ensures that only versioned releases trigger specific workflows.
* Added a `publish` job to the CI workflow to automate package publishing to PyPI when a new tag is pushed. This job includes steps for building and publishing release artifacts.

### Documentation Improvements:
* Updated `README.md` to reflect the installation of the package from PyPI instead of GitHub and revised command descriptions for better clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R47)
* Added licensing details (AGPL-3.0-or-later) to `README.md` and removed the previous reference to a `LICENSE` file.
* Introduced a new `release.md` file outlining the steps for preparing and tagging a new release.

### Project Metadata Updates:
* Updated `pyproject.toml` to reflect the new version `0.9.0`, added a `readme` field, classifiers, license information, and project URLs to improve the package's metadata on PyPI. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R22) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R31-R33)